### PR TITLE
Add additional statistics to coefficient result

### DIFF
--- a/src/disentangling_entanglement/pipelines/data_science/coefficients/nodes.py
+++ b/src/disentangling_entanglement/pipelines/data_science/coefficients/nodes.py
@@ -197,6 +197,8 @@ def iterate_noise(
             "coeffs_abs_mean",  # Mean absolute coefficient
             "coeffs_real_mean",  # Mean of real part only
             "coeffs_imag_mean",  # Mean of imaginary part only
+            "coeffs_full_real",  # All coefficients real part
+            "coeffs_full_imag",  # All coefficients imaginary part
             "frequencies",
         ]
     )
@@ -281,6 +283,8 @@ def iterate_noise(
             df.loc[step, "coeffs_abs_mean"] = np.abs(coeffs_pl).mean(axis=0)
             df.loc[step, "coeffs_real_mean"] = mean_real
             df.loc[step, "coeffs_imag_mean"] = mean_imag
+            df.loc[step, "coeffs_full_real"] = np.array(coeffs_pl).T.real
+            df.loc[step, "coeffs_full_imag"] = np.array(coeffs_pl).T.imag
             df.loc[step, "frequencies"] = np.array(freqs_pl).mean(axis=0)
 
             progress.advance(noise_it_task)


### PR DESCRIPTION
Iterate Noise experiments now contain additional information on the coefficients. 
Additionally to the previous statistics:
- `coeffs_abs_mean`: Mean of the absolute coefficients: $\bar{c}_\text{abs}$
- `coeffs_abs_var`: Variance of the absolute coefficients: $\frac{1}{N} \sum_{\omega = 0}^N  (|c_\omega| - \bar{c}_\text{abs}) ^2$


this PR introduces the following for each frequency (taken over all samples):
- `coeffs_var`: Variance of complex coefficients. This is computed via numpy, and basically computes $\frac{1}{N} \sum_{\omega = 0}^N \left((c_\omega - \bar{c}) \times (c_\omega - \bar{c})^*\right)$
- `coeffs_co_var_real_imag`: Covariance of real and imaginary part
- `coeffs_real_var`: Variance of real parts only
- `coeffs_imag_var`: Variance of imaginary parts only
- `coeffs_real_mean`: Mean of real part only
- `coeffs_imag_mean`: Mean of imaginary part only

And not only statistcs but also the full set of coefficients: 
- `coeffs_full_real`: Real part only
- `coeffs_full_imag`: Imaginary part only
